### PR TITLE
Simplify and improve mixins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ repositories {
 			includeGroup "maven.modrinth"
 		}
 	}
+
+	maven {
+		url "https://maven.bawnorton.com/releases"
+	}
 }
 
 fabricApi {
@@ -119,7 +123,8 @@ dependencies {
 
 	//Essential Compat
 	modCompileOnly "maven.modrinth:k2ZPuTBm:1.3.5.6"
-	
+
+	include(implementation(annotationProcessor("com.github.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0")))
 }
 
 processResources {

--- a/src/main/java/com/sp/SPBRevampedMixinCanceller.java
+++ b/src/main/java/com/sp/SPBRevampedMixinCanceller.java
@@ -1,0 +1,15 @@
+package com.sp;
+
+import com.bawnorton.mixinsquared.api.MixinCanceller;
+
+import java.util.List;
+
+public class SPBRevampedMixinCanceller implements MixinCanceller {
+    @Override
+    public boolean shouldCancel(List<String> targetClassNames, String mixinClassName) {
+        if (mixinClassName.equals("foundry.veil.mixin.client.deferred.AmbientOcclusionFaceMixin") || mixinClassName.equals("foundry/veil/mixin/client/deferred/AmbientOcclusionFaceMixin"))
+            return true;
+
+        return false;
+    }
+}

--- a/src/main/java/com/sp/mixin/AOFixMixin.java
+++ b/src/main/java/com/sp/mixin/AOFixMixin.java
@@ -2,16 +2,13 @@ package com.sp.mixin;
 
 import foundry.veil.api.client.render.VeilRenderSystem;
 import foundry.veil.api.client.render.deferred.VeilDeferredRenderer;
-import net.fabricmc.fabric.impl.client.indigo.Indigo;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.render.block.BlockModelRenderer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.BlockRenderView;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -29,218 +26,15 @@ import java.util.BitSet;
 @SuppressWarnings("UnstableApiUsage")
 @Mixin(targets = "net.minecraft.client.render.block.BlockModelRenderer$AmbientOcclusionCalculator")
 public abstract class AOFixMixin {
-
     @Shadow @Final
     float[] brightness;
 
-    @Shadow @Final
-    int[] light;
-
-    @Shadow protected abstract int getBrightness(int i, int j, int k, int l, float f, float g, float h, float m);
-
-
-    @Inject(method = "apply", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "apply", at = @At("HEAD"))
     private void fix(BlockRenderView world, BlockState state, BlockPos pos, Direction direction, float[] box, BitSet flags, boolean shaded, CallbackInfo ci){
-        ci.cancel();
-
-        BlockPos lightPos = flags.get(0) ? pos.offset(direction) : pos;
-        BlockModelRenderer.NeighborData neighborData = BlockModelRenderer.NeighborData.getData(direction);
-        BlockPos.Mutable searchPos = new BlockPos.Mutable();
-        BlockState searchState;
-        BlockModelRenderer.BrightnessCache brightnessCache = BlockModelRenderer.BRIGHTNESS_CACHE.get();
-
-
-        searchPos.set(lightPos, neighborData.faces[0]);
-        searchState = world.getBlockState(searchPos);
-        int light1 = brightnessCache.getInt(searchState, world, searchPos);
-        float ao1 = brightnessCache.getFloat(searchState, world, searchPos);
-
-        boolean bl = !searchState.shouldBlockVision(world, searchPos) || searchState.getOpacity(world, searchPos) == 0;
-
-
-        searchPos.set(lightPos, neighborData.faces[1]);
-        searchState = world.getBlockState(searchPos);
-        int light2 = brightnessCache.getInt(searchState, world, searchPos);
-        float ao2 = brightnessCache.getFloat(searchState, world, searchPos);
-
-        boolean bl2 = !searchState.shouldBlockVision(world, searchPos) || searchState.getOpacity(world, searchPos) == 0;
-
-
-        searchPos.set(lightPos, neighborData.faces[2]);
-        searchState = world.getBlockState(searchPos);
-        int light3 = brightnessCache.getInt(searchState, world, searchPos);
-        float ao3 = brightnessCache.getFloat(searchState, world, searchPos);
-
-        boolean bl3 = !searchState.shouldBlockVision(world, searchPos) || searchState.getOpacity(world, searchPos) == 0;
-
-
-        searchPos.set(lightPos, neighborData.faces[3]);
-        searchState = world.getBlockState(searchPos);
-        int light4 = brightnessCache.getInt(searchState, world, searchPos);
-        float ao4 = brightnessCache.getFloat(searchState, world, searchPos);
-
-        boolean bl4 = !searchState.shouldBlockVision(world, searchPos) || searchState.getOpacity(world, searchPos) == 0;
-
-
-
-        float n;
-        int o;
-        if (!bl3 && !bl) {
-            n = ao1;
-            o = light1;
-        } else {
-            searchPos.set(lightPos).move(neighborData.faces[0]).move(neighborData.faces[2]);
-            searchState = world.getBlockState(searchPos);
-            n = brightnessCache.getFloat(searchState, world, searchPos);
-            o = brightnessCache.getInt(searchState, world, searchPos);
-        }
-
-        float p;
-        int q;
-        if (!bl4 && !bl) {
-            p = ao1;
-            q = light1;
-        } else {
-            searchPos.set(lightPos).move(neighborData.faces[0]).move(neighborData.faces[3]);
-            searchState = world.getBlockState(searchPos);
-            p = brightnessCache.getFloat(searchState, world, searchPos);
-            q = brightnessCache.getInt(searchState, world, searchPos);
-        }
-
-        float r;
-        int s;
-        if (!bl3 && !bl2) {
-            r = ao1;
-            s = light1;
-        } else {
-            searchPos.set(lightPos).move(neighborData.faces[1]).move(neighborData.faces[2]);
-            searchState = world.getBlockState(searchPos);
-            r = brightnessCache.getFloat(searchState, world, searchPos);
-            s = brightnessCache.getInt(searchState, world, searchPos);
-        }
-
-        float t;
-        int u;
-        if (!bl4 && !bl2) {
-            t = ao1;
-            u = light1;
-        } else {
-            searchPos.set(lightPos).move(neighborData.faces[1]).move(neighborData.faces[3]);
-            searchState = world.getBlockState(searchPos);
-            t = brightnessCache.getFloat(searchState, world, searchPos);
-            u = brightnessCache.getInt(searchState, world, searchPos);
-        }
-
-        int v = brightnessCache.getInt(state, world, pos);
-        searchPos.set(pos, direction);
-        searchState = world.getBlockState(searchPos);
-
-
-        if (flags.get(0) || !searchState.isOpaqueFullCube(world, searchPos)) {
-            v = brightnessCache.getInt(searchState, world, searchPos);
-        }
-
-        float w = flags.get(0)
-                ? brightnessCache.getFloat(world.getBlockState(lightPos), world, lightPos)
-                : brightnessCache.getFloat(world.getBlockState(pos), world, pos);
-
-        BlockModelRenderer.Translation translation = BlockModelRenderer.Translation.getTranslations(direction);
-
-        float x = (ao4 + ao1 + p + w) * 0.25F;
-        float y = (ao3 + ao1 + n + w) * 0.25F;
-        float z = (ao3 + ao2 + r + w) * 0.25F;
-        float aa = (ao4 + ao2 + t + w) * 0.25F;
-        if (flags.get(1) && neighborData.nonCubicWeight) {
-            float ab = box[neighborData.field_4192[0].shape] * box[neighborData.field_4192[1].shape];
-            float ac = box[neighborData.field_4192[2].shape] * box[neighborData.field_4192[3].shape];
-            float ad = box[neighborData.field_4192[4].shape] * box[neighborData.field_4192[5].shape];
-            float ae = box[neighborData.field_4192[6].shape] * box[neighborData.field_4192[7].shape];
-            float af = box[neighborData.field_4185[0].shape] * box[neighborData.field_4185[1].shape];
-            float ag = box[neighborData.field_4185[2].shape] * box[neighborData.field_4185[3].shape];
-            float ah = box[neighborData.field_4185[4].shape] * box[neighborData.field_4185[5].shape];
-            float ai = box[neighborData.field_4185[6].shape] * box[neighborData.field_4185[7].shape];
-            float aj = box[neighborData.field_4180[0].shape] * box[neighborData.field_4180[1].shape];
-            float ak = box[neighborData.field_4180[2].shape] * box[neighborData.field_4180[3].shape];
-            float al = box[neighborData.field_4180[4].shape] * box[neighborData.field_4180[5].shape];
-            float am = box[neighborData.field_4180[6].shape] * box[neighborData.field_4180[7].shape];
-            float an = box[neighborData.field_4188[0].shape] * box[neighborData.field_4188[1].shape];
-            float ao = box[neighborData.field_4188[2].shape] * box[neighborData.field_4188[3].shape];
-            float ap = box[neighborData.field_4188[4].shape] * box[neighborData.field_4188[5].shape];
-            float aq = box[neighborData.field_4188[6].shape] * box[neighborData.field_4188[7].shape];
-            this.brightness[translation.firstCorner] = x * ab + y * ac + z * ad + aa * ae;
-            this.brightness[translation.secondCorner] = x * af + y * ag + z * ah + aa * ai;
-            this.brightness[translation.thirdCorner] = x * aj + y * ak + z * al + aa * am;
-            this.brightness[translation.fourthCorner] = x * an + y * ao + z * ap + aa * aq;
-            int ar = this.meanBrightness(light4, light1, q, v);
-            int as = this.meanBrightness(light3, light1, o, v);
-            int at = this.meanBrightness(light3, light2, s, v);
-            int au = this.meanBrightness(light4, light2, u, v);
-            this.light[translation.firstCorner] = this.getBrightness(ar, as, at, au, ab, ac, ad, ae);
-            this.light[translation.firstCorner] = this.getBrightness(ar, as, at, au, ab, ac, ad, ae);
-            this.light[translation.secondCorner] = this.getBrightness(ar, as, at, au, af, ag, ah, ai);
-            this.light[translation.thirdCorner] = this.getBrightness(ar, as, at, au, aj, ak, al, am);
-            this.light[translation.fourthCorner] = this.getBrightness(ar, as, at, au, an, ao, ap, aq);
-        } else {
-            this.light[translation.firstCorner] = this.meanBrightness(light4, light1, q, v);
-            this.light[translation.secondCorner] = this.meanBrightness(light3, light1, o, v);
-            this.light[translation.thirdCorner] = this.meanBrightness(light3, light2, s, v);
-            this.light[translation.fourthCorner] = this.meanBrightness(light4, light2, u, v);
-            this.brightness[translation.firstCorner] = x;
-            this.brightness[translation.secondCorner] = y;
-            this.brightness[translation.thirdCorner] = z;
-            this.brightness[translation.fourthCorner] = aa;
-        }
-
         //Reinserting veil's "Disable Ambient Occlusion"
         VeilDeferredRenderer deferredRenderer = VeilRenderSystem.renderer().getDeferredRenderer();
         if (!deferredRenderer.getLightRenderer().isAmbientOcclusionEnabled()) {
             Arrays.fill(this.brightness, 1.0F);
         }
     }
-
-
-    /**These 4 methods are also from
-     * {@link net.fabricmc.fabric.impl.client.indigo.renderer.aocalc.AoCalculator}
-     */
-    @Unique
-    private int meanBrightness(int lightA, int lightB, int lightC, int lightD) {
-        if (Indigo.FIX_MEAN_LIGHT_CALCULATION) {
-            if (lightA == 0 || lightB == 0 || lightC == 0 || lightD == 0) {
-                // Normalize values to non-zero minimum
-                final int min = nonZeroMin(nonZeroMin(lightA, lightB), nonZeroMin(lightC, lightD));
-
-                lightA = Math.max(lightA, min);
-                lightB = Math.max(lightB, min);
-                lightC = Math.max(lightC, min);
-                lightD = Math.max(lightD, min);
-            }
-
-            return meanInnerBrightness(lightA, lightB, lightC, lightD);
-        } else {
-            return vanillaMeanBrightness(lightA, lightB, lightC, lightD);
-        }
-    }
-
-    @Unique
-    private int meanInnerBrightness(int a, int b, int c, int d) {
-        // bitwise divide by 4, clamp to expected (positive) range
-        return a + b + c + d >> 2 & 0xFF00FF;
-    }
-
-    @Unique
-    private int vanillaMeanBrightness(int a, int b, int c, int d) {
-        if (a == 0) a = d;
-        if (b == 0) b = d;
-        if (c == 0) c = d;
-        // bitwise divide by 4, clamp to expected (positive) range
-        return a + b + c + d >> 2 & 0xFF00FF;
-    }
-
-    @Unique
-    private int nonZeroMin(int a, int b) {
-        if (a == 0) return b;
-        if (b == 0) return a;
-        return Math.min(a, b);
-    }
-
 }

--- a/src/main/java/com/sp/mixin/DisableJumpMixin.java
+++ b/src/main/java/com/sp/mixin/DisableJumpMixin.java
@@ -1,5 +1,7 @@
 package com.sp.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.sp.SPBRevampedClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.input.KeyboardInput;
@@ -7,18 +9,17 @@ import net.minecraft.entity.player.PlayerEntity;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(KeyboardInput.class)
 public class DisableJumpMixin {
 
-    @Redirect(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/client/input/KeyboardInput;jumping:Z", opcode = Opcodes.PUTFIELD))
-    private void disableJumping(KeyboardInput instance, boolean value){
+    @WrapOperation(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/client/input/KeyboardInput;jumping:Z", opcode = Opcodes.PUTFIELD))
+    private void disableJumping(KeyboardInput instance, boolean value, Operation<Void> original){
         PlayerEntity player = MinecraftClient.getInstance().player;
 
         if(player != null) {
             if(player.isTouchingWater() || player.isCreative() || player.isSpectator() || !SPBRevampedClient.isInBackrooms()) {
-                instance.jumping = value;
+                original.call(instance, value);
             } else {
                 instance.jumping = false;
             }

--- a/src/main/java/com/sp/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/sp/mixin/LivingEntityMixin.java
@@ -1,20 +1,22 @@
 package com.sp.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.sp.init.BackroomsLevels;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.world.ServerWorld;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LivingEntity.class)
 public class LivingEntityMixin {
 
-    @Redirect(method = "fall", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;spawnParticles(Lnet/minecraft/particle/ParticleEffect;DDDIDDDD)I"))
-    private <T extends ParticleEffect> int noFallParticles(ServerWorld instance, T particle, double x, double y, double z, int count, double deltaX, double deltaY, double deltaZ, double speed){
+    @WrapOperation(method = "fall", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;spawnParticles(Lnet/minecraft/particle/ParticleEffect;DDDIDDDD)I"))
+    private <T extends ParticleEffect> int noFallParticles(ServerWorld instance, T particle, double x, double y, double z, int count, double deltaX, double deltaY, double deltaZ, double speed, Operation<Integer> original){
         if(!BackroomsLevels.isInBackrooms(instance.getRegistryKey())){
-            return instance.spawnParticles(particle, x, y, z, count, deltaX, deltaY, deltaZ, speed);
+            //noinspection MixinExtrasOperationParameters
+            return original.call(instance, particle, x, y, z, count, deltaX, deltaY, deltaZ, speed);
         }
 
         return 0;

--- a/src/main/java/com/sp/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/com/sp/mixin/LivingEntityRendererMixin.java
@@ -1,5 +1,6 @@
 package com.sp.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.sp.cca_stuff.InitializeComponents;
 import com.sp.cca_stuff.SmilerComponent;
 import com.sp.entity.custom.SmilerEntity;
@@ -10,9 +11,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LivingEntityRenderer.class)
@@ -24,12 +23,12 @@ public abstract class LivingEntityRendererMixin<T extends LivingEntity, M extend
         this.entity = livingEntity;
     }
 
-    @ModifyConstant(method = "render(Lnet/minecraft/entity/LivingEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V",
-            constant = {
-                @Constant(floatValue = 1.0f, ordinal = 3),
-                @Constant(floatValue = 1.0f, ordinal = 4),
-                @Constant(floatValue = 1.0f, ordinal = 5),
-                @Constant(floatValue = 1.0f, ordinal = 6)
+    @ModifyExpressionValue(method = "render(Lnet/minecraft/entity/LivingEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V",
+            at = {
+                @At(value = "CONSTANT", args = "floatValue=1.0", ordinal = 3),
+                @At(value = "CONSTANT", args = "floatValue=1.0", ordinal = 4),
+                @At(value = "CONSTANT", args = "floatValue=1.0", ordinal = 5),
+                @At(value = "CONSTANT", args = "floatValue=1.0", ordinal = 6)
             })
     private float setOpacity(float constant){
         if(entity instanceof SmilerEntity) {

--- a/src/main/java/com/sp/mixin/MutableUniformAccessMixin.java
+++ b/src/main/java/com/sp/mixin/MutableUniformAccessMixin.java
@@ -1,6 +1,5 @@
 package com.sp.mixin;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.sp.SPBRevampedClient;
 import com.sp.render.PoolroomsDayCycle;
 import foundry.veil.api.client.render.shader.program.MutableUniformAccess;
@@ -8,11 +7,12 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.client.util.Window;
 import net.minecraft.screen.PlayerScreenHandler;
-import org.joml.Matrix4fc;
 import org.joml.Vector3fc;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = MutableUniformAccess.class, remap = false)
 public interface MutableUniformAccessMixin {
@@ -20,30 +20,10 @@ public interface MutableUniformAccessMixin {
 
     @Shadow void setFloat(CharSequence name, float value);
 
-    @Shadow void setMatrix(CharSequence name, Matrix4fc value);
-
-    @Shadow void setInt(CharSequence name, int value);
-
-    @Shadow void setVector(CharSequence name, float[] values);
-
     @Shadow void setVector(CharSequence name, Vector3fc value);
 
-    /**
-     * @author SpacePotato
-     * @reason Because apparently you can't inject into interfaces :\
-     */
-    @Overwrite
-    default void applyRenderSystem() {
-        this.setMatrix("RenderModelViewMat", RenderSystem.getModelViewMatrix());
-        this.setMatrix("RenderProjMat", RenderSystem.getProjectionMatrix());
-        this.setVector("ColorModulator", RenderSystem.getShaderColor());
-        this.setFloat("GlintAlpha", RenderSystem.getShaderGlintAlpha());
-        this.setFloat("FogStart", RenderSystem.getShaderFogStart());
-        this.setFloat("FogEnd", RenderSystem.getShaderFogEnd());
-        this.setVector("FogColor", RenderSystem.getShaderFogColor());
-        this.setInt("FogShape", RenderSystem.getShaderFogShape().getId());
-        this.setMatrix("TextureMatrix", RenderSystem.getTextureMatrix());
-        this.setFloat("GameTime", RenderSystem.getShaderGameTime());
+    @Inject(method = "applyRenderSystem", at = @At("TAIL"))
+    default void applyRenderSystem(CallbackInfo ci) {
 
         if(SPBRevampedClient.cameraBobOffset != null) {
             this.setVector("cameraBobOffset", SPBRevampedClient.cameraBobOffset);

--- a/src/main/java/com/sp/mixin/PlaySprintSoundMixin.java
+++ b/src/main/java/com/sp/mixin/PlaySprintSoundMixin.java
@@ -1,5 +1,7 @@
 package com.sp.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.sp.block.SprintBlockSoundGroup;
 import net.minecraft.entity.Entity;
@@ -8,19 +10,18 @@ import net.minecraft.sound.SoundEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Entity.class)
 public abstract class PlaySprintSoundMixin {
 
     @Shadow public abstract void playSound(SoundEvent sound, float volume, float pitch);
 
-    @Redirect(method = "playStepSound", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;playSound(Lnet/minecraft/sound/SoundEvent;FF)V"))
-    private void playSprintSound(Entity instance, SoundEvent sound, float volume, float pitch, @Local BlockSoundGroup blockSoundGroup){
+    @WrapOperation(method = "playStepSound", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;playSound(Lnet/minecraft/sound/SoundEvent;FF)V"))
+    private void playSprintSound(Entity instance, SoundEvent sound, float volume, float pitch, Operation<Void> original, @Local BlockSoundGroup blockSoundGroup){
         if(blockSoundGroup instanceof SprintBlockSoundGroup && instance.isSprinting()) {
             this.playSound(((SprintBlockSoundGroup) blockSoundGroup).getSprintingSound(), blockSoundGroup.getVolume(), blockSoundGroup.getPitch());
         } else {
-            this.playSound(blockSoundGroup.getStepSound(), blockSoundGroup.getVolume() * 0.15f, blockSoundGroup.getPitch());
+            original.call(instance, sound, volume, pitch);
         }
     }
 

--- a/src/main/java/com/sp/mixin/PlayerEntityMixin.java
+++ b/src/main/java/com/sp/mixin/PlayerEntityMixin.java
@@ -25,8 +25,6 @@ public abstract class PlayerEntityMixin extends Entity {
 
         if (playerComponent.shouldNoClip()) {
             this.noClip = playerComponent.shouldNoClip();
-        } else {
-            this.noClip = this.isSpectator();
         }
     }
 }

--- a/src/main/java/com/sp/mixin/VanillaLightRenderer.java
+++ b/src/main/java/com/sp/mixin/VanillaLightRenderer.java
@@ -1,5 +1,7 @@
 package com.sp.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.sp.init.BackroomsLevels;
 import foundry.veil.api.client.render.shader.program.ShaderProgram;
@@ -7,18 +9,17 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.Direction;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(value = foundry.veil.impl.client.render.deferred.light.VanillaLightRenderer.class, remap = false)
 public class VanillaLightRenderer {
 
-    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lfoundry/veil/api/client/render/shader/program/ShaderProgram;setFloat(Ljava/lang/CharSequence;F)V"))
-    private void noWeirdBrightnessThing(ShaderProgram instance, CharSequence name, float value, @Local(argsOnly = true) ClientWorld level, @Local Direction direction) {
+    @WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lfoundry/veil/api/client/render/shader/program/ShaderProgram;setFloat(Ljava/lang/CharSequence;F)V"))
+    private void noWeirdBrightnessThing(ShaderProgram instance, CharSequence name, float value, Operation<Void> original, @Local(argsOnly = true) ClientWorld level, @Local Direction direction) {
         if(level.getRegistryKey() == BackroomsLevels.POOLROOMS_WORLD_KEY){
             instance.setFloat("LightShading" + direction.ordinal(), 0.9f);
+        } else {
+            original.call(instance, name, value);
         }
-
-        instance.setFloat("LightShading" + direction.ordinal(), level.getBrightness(direction, true));
     }
 
 }

--- a/src/main/java/com/sp/mixin/WorldRendererMixin.java
+++ b/src/main/java/com/sp/mixin/WorldRendererMixin.java
@@ -1,5 +1,6 @@
 package com.sp.mixin;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.sp.SPBRevampedClient;
 import com.sp.init.BackroomsLevels;
@@ -18,7 +19,6 @@ import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import static org.lwjgl.opengl.GL11C.*;
@@ -83,9 +83,9 @@ public abstract class WorldRendererMixin {
     }
 
 
-    @Redirect(method = "processWorldEvent", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/sound/SoundManager;play(Lnet/minecraft/client/sound/SoundInstance;)V"))
-    private void stopTravelSound(SoundManager instance, SoundInstance sound){
-
+    @WrapWithCondition(method = "processWorldEvent", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/sound/SoundManager;play(Lnet/minecraft/client/sound/SoundInstance;)V"))
+    private boolean stopTravelSound(SoundManager instance, SoundInstance sound){
+        return false;
     }
 
 }

--- a/src/main/java/com/sp/mixin/arealightfix/AreaLightMixin.java
+++ b/src/main/java/com/sp/mixin/arealightfix/AreaLightMixin.java
@@ -12,8 +12,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.nio.ByteBuffer;
 
@@ -26,21 +25,9 @@ public abstract class AreaLightMixin extends Light implements InstancedLight, Po
     @Shadow @Final private static float MAX_ANGLE_SIZE;
     @Shadow protected float distance;
 
-    @Inject(method = "store", at = @At("HEAD"), cancellable = true)
-    private void lightFix(ByteBuffer buffer, CallbackInfo ci){
-        ci.cancel();
-        this.matrix.getFloats(buffer.position(), buffer);
-        buffer.position(buffer.position() + Float.BYTES * 16);
-
-        buffer.putFloat(this.color.x() * this.brightness);
-        buffer.putFloat(this.color.y() * this.brightness);
-        buffer.putFloat(this.color.z() * this.brightness);
-
-        this.size.get(buffer.position(), buffer);
-        buffer.position(buffer.position() + Float.BYTES * 2);
-
-        buffer.putFloat((float) MathHelper.clamp((int) (this.angle * MAX_ANGLE_SIZE), 0, 65535));
-        buffer.putFloat(this.distance);
+    @Redirect(method = "store", at = @At(value = "INVOKE", target = "Ljava/nio/ByteBuffer;putShort(S)Ljava/nio/ByteBuffer;"))
+    private ByteBuffer lightFix(ByteBuffer instance, short i){
+        return instance.putFloat((float) MathHelper.clamp((int) (this.angle * MAX_ANGLE_SIZE), 0, 65535));
     }
 
 }

--- a/src/main/java/com/sp/mixin/arealightfix/AreaLightRendererMixin.java
+++ b/src/main/java/com/sp/mixin/arealightfix/AreaLightRendererMixin.java
@@ -3,16 +3,10 @@ package com.sp.mixin.arealightfix;
 import foundry.veil.api.client.render.deferred.light.AreaLight;
 import foundry.veil.api.client.render.deferred.light.renderer.InstancedLightRenderer;
 import foundry.veil.impl.client.render.deferred.light.AreaLightRenderer;
+import org.lwjgl.opengl.GL20C;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import static org.lwjgl.opengl.GL11C.GL_FLOAT;
-import static org.lwjgl.opengl.GL20C.glEnableVertexAttribArray;
-import static org.lwjgl.opengl.GL20C.glVertexAttribPointer;
-import static org.lwjgl.opengl.GL33C.glVertexAttribDivisor;
 
 @Mixin(value = AreaLightRenderer.class, remap = false)
 public abstract class AreaLightRendererMixin extends InstancedLightRenderer<AreaLight> {
@@ -26,37 +20,19 @@ public abstract class AreaLightRendererMixin extends InstancedLightRenderer<Area
         return Float.BYTES * 23;
     }
 
-    @Inject(method = "setupBufferState", at = @At("HEAD"), cancellable = true)
-    private void lightFix(CallbackInfo ci){
-        ci.cancel();
+    @ModifyArg(method = "setupBufferState", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL20C;glVertexAttribPointer(IIIZIJ)V", ordinal = 6), index = 2)
+    private int lightFixUseFloat(int original) {
+        return GL20C.GL_FLOAT;
+    }
 
-        glEnableVertexAttribArray(1);
-        glEnableVertexAttribArray(2);
-        glEnableVertexAttribArray(3);
-        glEnableVertexAttribArray(4);
-        glEnableVertexAttribArray(5);
-        glEnableVertexAttribArray(6);
-        glEnableVertexAttribArray(7);
-        glEnableVertexAttribArray(8);
+    @ModifyArg(method = "setupBufferState", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL20C;glVertexAttribPointer(IIIZIJ)V", ordinal = 6))
+    private boolean lightFixUseUnnormalized(boolean original) {
+        return false;
+    }
 
-        glVertexAttribPointer(1, 4, GL_FLOAT, false, this.lightSize, 0);
-        glVertexAttribPointer(2, 4, GL_FLOAT, false, this.lightSize, Float.BYTES * 4);
-        glVertexAttribPointer(3, 4, GL_FLOAT, false, this.lightSize, Float.BYTES * 8);
-        glVertexAttribPointer(4, 4, GL_FLOAT, false, this.lightSize, Float.BYTES * 12); // matrix !
-
-        glVertexAttribPointer(5, 3, GL_FLOAT, false, this.lightSize, Float.BYTES * 16); // color
-        glVertexAttribPointer(6, 2, GL_FLOAT, false, this.lightSize, Float.BYTES * 19); // size
-        glVertexAttribPointer(7, 1, GL_FLOAT, false, this.lightSize, Float.BYTES * 21); // angle
-        glVertexAttribPointer(8, 1, GL_FLOAT, false, this.lightSize, Float.BYTES * 22); // distance
-
-        glVertexAttribDivisor(1, 1);
-        glVertexAttribDivisor(2, 1);
-        glVertexAttribDivisor(3, 1);
-        glVertexAttribDivisor(4, 1);
-        glVertexAttribDivisor(5, 1);
-        glVertexAttribDivisor(6, 1);
-        glVertexAttribDivisor(7, 1);
-        glVertexAttribDivisor(8, 1);
+    @ModifyArg(method = "setupBufferState", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL20C;glVertexAttribPointer(IIIZIJ)V", ordinal = 7))
+    private long lightFix(long normalized){
+        return Float.BYTES * 22;
     }
 
 }

--- a/src/main/java/com/sp/mixin/disableloadingscreen/MinecraftClientMixin.java
+++ b/src/main/java/com/sp/mixin/disableloadingscreen/MinecraftClientMixin.java
@@ -1,22 +1,18 @@
 package com.sp.mixin.disableloadingscreen;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.sp.SPBRevampedClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.ProgressScreen;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(MinecraftClient.class)
 public abstract class MinecraftClientMixin {
 
-    @Redirect(method = "joinWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ProgressScreen;setTitle(Lnet/minecraft/text/Text;)V"))
-    private void doNothing(ProgressScreen instance, Text title){
-        if (SPBRevampedClient.isInBackrooms()) {
-            return;
-        }
-
-        instance.setTitle(Text.translatable("connect.joining"));
+    @WrapWithCondition(method = "joinWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ProgressScreen;setTitle(Lnet/minecraft/text/Text;)V"))
+    private boolean doNothing(ProgressScreen instance, Text title){
+        return !SPBRevampedClient.isInBackrooms();
     }
 }

--- a/src/main/java/com/sp/mixin/hudandresolution/DontRenderHandMixin.java
+++ b/src/main/java/com/sp/mixin/hudandresolution/DontRenderHandMixin.java
@@ -1,26 +1,18 @@
 package com.sp.mixin.hudandresolution;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.sp.compat.modmenu.ConfigStuff;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.item.HeldItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Arm;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(HeldItemRenderer.class)
 public abstract class DontRenderHandMixin {
-
-    @Shadow protected abstract void renderArmHoldingItem(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, float equipProgress, float swingProgress, Arm arm);
-
-    @Redirect(method = "renderFirstPersonItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderArmHoldingItem(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IFFLnet/minecraft/util/Arm;)V"))
-    private void cancel(HeldItemRenderer instance, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, float equipProgress, float swingProgress, Arm arm){
-        if (!ConfigStuff.showHands) {
-            return;
-        }
-
-        this.renderArmHoldingItem(matrices, vertexConsumers, light, equipProgress, swingProgress, arm);
+    @WrapWithCondition(method = "renderFirstPersonItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/item/HeldItemRenderer;renderArmHoldingItem(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IFFLnet/minecraft/util/Arm;)V"))
+    private boolean cancel(HeldItemRenderer instance, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, float equipProgress, float swingProgress, Arm arm){
+        return ConfigStuff.showHands;
     }
 }

--- a/src/main/java/com/sp/mixin/pbr/ChunkBuilderMixin.java
+++ b/src/main/java/com/sp/mixin/pbr/ChunkBuilderMixin.java
@@ -1,25 +1,26 @@
 package com.sp.mixin.pbr;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
-import com.sp.render.VertexFormats;
 import com.sp.render.RenderLayers;
+import com.sp.render.VertexFormats;
 import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexFormat;
 import net.minecraft.client.render.chunk.ChunkBuilder;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ChunkBuilder.BuiltChunk.RebuildTask.class)
 public class ChunkBuilderMixin {
 
-    @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/chunk/ChunkBuilder$BuiltChunk;beginBufferBuilding(Lnet/minecraft/client/render/BufferBuilder;)V"))
-    private void beginPBR(ChunkBuilder.BuiltChunk instance, BufferBuilder buffer, @Local RenderLayer renderLayer){
+    @WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/chunk/ChunkBuilder$BuiltChunk;beginBufferBuilding(Lnet/minecraft/client/render/BufferBuilder;)V"))
+    private void beginPBR(ChunkBuilder.BuiltChunk instance, BufferBuilder buffer, Operation<Void> original, @Local RenderLayer renderLayer){
         if(renderLayer == RenderLayers.getPbrLayer()){
             buffer.begin(VertexFormat.DrawMode.QUADS, VertexFormats.PBR);
         } else {
-            buffer.begin(VertexFormat.DrawMode.QUADS, net.minecraft.client.render.VertexFormats.POSITION_COLOR_TEXTURE_LIGHT_NORMAL);
+            original.call(instance, buffer);
         }
     }
 

--- a/src/main/java/com/sp/mixin/respawnsystem/DeathScreenMixin.java
+++ b/src/main/java/com/sp/mixin/respawnsystem/DeathScreenMixin.java
@@ -1,5 +1,7 @@
 package com.sp.mixin.respawnsystem;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.sp.init.BackroomsLevels;
 import net.minecraft.client.gui.screen.DeathScreen;
 import net.minecraft.client.gui.screen.Screen;
@@ -10,7 +12,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(DeathScreen.class)
@@ -40,8 +41,8 @@ public abstract class DeathScreenMixin extends Screen {
 
 
     //Remove the functionality of the respawn button
-    @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;builder(Lnet/minecraft/text/Text;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)Lnet/minecraft/client/gui/widget/ButtonWidget$Builder;", ordinal = 0))
-    private ButtonWidget.Builder disableRespawnButton(Text message, ButtonWidget.PressAction onPress){
+    @WrapOperation(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;builder(Lnet/minecraft/text/Text;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)Lnet/minecraft/client/gui/widget/ButtonWidget$Builder;", ordinal = 0))
+    private ButtonWidget.Builder disableRespawnButton(Text message, ButtonWidget.PressAction onPress, Operation<ButtonWidget.Builder> original){
         if (this.isInBackrooms()) {
             return new ButtonWidget.Builder(message, button -> {
                 firstTimeDead = false;
@@ -49,12 +50,12 @@ public abstract class DeathScreenMixin extends Screen {
             });
         }
 
-        return new ButtonWidget.Builder(message, onPress);
+        return original.call(message, onPress);
     }
 
     //Remove the functionality of the title screen button
-    @Redirect(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;builder(Lnet/minecraft/text/Text;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)Lnet/minecraft/client/gui/widget/ButtonWidget$Builder;", ordinal = 1))
-    private ButtonWidget.Builder disableTitleScreenButton(Text message, ButtonWidget.PressAction onPress){
+    @WrapOperation(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;builder(Lnet/minecraft/text/Text;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)Lnet/minecraft/client/gui/widget/ButtonWidget$Builder;", ordinal = 1))
+    private ButtonWidget.Builder disableTitleScreenButton(Text message, ButtonWidget.PressAction onPress, Operation<ButtonWidget.Builder> original){
         if (this.isInBackrooms()) {
             return new ButtonWidget.Builder(message, button -> {
                 firstTimeDead = false;
@@ -62,7 +63,7 @@ public abstract class DeathScreenMixin extends Screen {
             });
         }
 
-        return new ButtonWidget.Builder(message, onPress);
+        return original.call(message, onPress);
     }
 
 

--- a/src/main/java/com/sp/mixin/skinstolen/ChatScreenMixin.java
+++ b/src/main/java/com/sp/mixin/skinstolen/ChatScreenMixin.java
@@ -1,5 +1,7 @@
 package com.sp.mixin.skinstolen;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.sp.cca_stuff.InitializeComponents;
 import com.sp.cca_stuff.PlayerComponent;
 import com.sp.entity.client.SkinWalkerCapturedFlavorText;
@@ -9,7 +11,6 @@ import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ChatScreen.class)
 public abstract class ChatScreenMixin extends Screen{
@@ -18,23 +19,23 @@ public abstract class ChatScreenMixin extends Screen{
         super(title);
     }
 
-    @Redirect(method = "sendMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendChatMessage(Ljava/lang/String;)V"))
-    private void noOneCanHearYouScream(ClientPlayNetworkHandler instance, String content){
+    @WrapOperation(method = "sendMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendChatMessage(Ljava/lang/String;)V"))
+    private void noOneCanHearYouScream(ClientPlayNetworkHandler instance, String content, Operation<Void> original){
         PlayerComponent component = InitializeComponents.PLAYER.get(this.client.player);
 
         if(!component.hasBeenCaptured()){
-            instance.sendChatMessage(content);
+            original.call(instance, content);
         } else {
             SkinWalkerCapturedFlavorText.triedToChat = true;
         }
     }
 
-    @Redirect(method = "sendMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendChatCommand(Ljava/lang/String;)V"))
-    private void noOneCanHearYouScream2(ClientPlayNetworkHandler instance, String content){
+    @WrapOperation(method = "sendMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayNetworkHandler;sendChatCommand(Ljava/lang/String;)V"))
+    private void noOneCanHearYouScream2(ClientPlayNetworkHandler instance, String content, Operation<Void> original){
         PlayerComponent component2 = InitializeComponents.PLAYER.get(this.client.player);
 
         if(!component2.hasBeenCaptured() || content.contains("release")){
-            instance.sendChatCommand(content);
+            original.call(instance, content);
         } else {
             SkinWalkerCapturedFlavorText.triedToChat = true;
         }

--- a/src/main/java/com/sp/mixin/skinstolen/GameMenuScreenMixin.java
+++ b/src/main/java/com/sp/mixin/skinstolen/GameMenuScreenMixin.java
@@ -1,5 +1,7 @@
 package com.sp.mixin.skinstolen;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.sp.cca_stuff.InitializeComponents;
 import com.sp.cca_stuff.PlayerComponent;
 import com.sp.entity.client.SkinWalkerCapturedFlavorText;
@@ -11,7 +13,6 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(GameMenuScreen.class)
 public abstract class GameMenuScreenMixin extends Screen {
@@ -21,8 +22,8 @@ public abstract class GameMenuScreenMixin extends Screen {
     }
 
     //You can't escape
-    @Redirect(method = "initWidgets", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;builder(Lnet/minecraft/text/Text;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)Lnet/minecraft/client/gui/widget/ButtonWidget$Builder;", ordinal = 1))
-    private ButtonWidget.Builder noEscape(Text message, ButtonWidget.PressAction onPress){
+    @WrapOperation(method = "initWidgets", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/ButtonWidget;builder(Lnet/minecraft/text/Text;Lnet/minecraft/client/gui/widget/ButtonWidget$PressAction;)Lnet/minecraft/client/gui/widget/ButtonWidget$Builder;", ordinal = 1))
+    private ButtonWidget.Builder noEscape(Text message, ButtonWidget.PressAction onPress, Operation<ButtonWidget.Builder> original){
         MinecraftClient client1 = MinecraftClient.getInstance();
         if(client1.player != null) {
             PlayerComponent component = InitializeComponents.PLAYER.get(client1.player);
@@ -35,6 +36,6 @@ public abstract class GameMenuScreenMixin extends Screen {
             }
         }
 
-        return new ButtonWidget.Builder(message, onPress);
+        return original.call(message, onPress);
     }
 }

--- a/src/main/java/com/sp/mixin/skinstolen/MinecraftClientMixin.java
+++ b/src/main/java/com/sp/mixin/skinstolen/MinecraftClientMixin.java
@@ -1,5 +1,7 @@
 package com.sp.mixin.skinstolen;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.sp.cca_stuff.InitializeComponents;
 import com.sp.cca_stuff.PlayerComponent;
 import com.sp.entity.client.SkinWalkerCapturedFlavorText;
@@ -7,17 +9,16 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(MinecraftClient.class)
 public class MinecraftClientMixin {
 
-    @Redirect(method = "handleInputEvents", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setScreen(Lnet/minecraft/client/gui/screen/Screen;)V", ordinal = 1))
-    private void disableInventory(MinecraftClient instance, Screen screen){
+    @WrapOperation(method = "handleInputEvents", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setScreen(Lnet/minecraft/client/gui/screen/Screen;)V", ordinal = 1))
+    private void disableInventory(MinecraftClient instance, Screen screen, Operation<Void> original){
         if(instance.player != null) {
             PlayerComponent component = InitializeComponents.PLAYER.get(instance.player);
             if (!component.hasBeenCaptured()) {
-                instance.setScreen(screen);
+                original.call(instance, screen);
             } else {
                 SkinWalkerCapturedFlavorText.triedToOpenInventory = true;
             }

--- a/src/main/java/com/sp/mixin/skinstolen/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/sp/mixin/skinstolen/ServerPlayerEntityMixin.java
@@ -1,5 +1,7 @@
 package com.sp.mixin.skinstolen;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.sp.cca_stuff.InitializeComponents;
 import com.sp.cca_stuff.PlayerComponent;
 import net.minecraft.entity.Entity;
@@ -7,17 +9,16 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin {
 
-    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;setCameraEntity(Lnet/minecraft/entity/Entity;)V", ordinal = 0))
-    private void cantEscapeSpectating(ServerPlayerEntity instance, Entity entity){
+    @WrapOperation(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;setCameraEntity(Lnet/minecraft/entity/Entity;)V", ordinal = 0))
+    private void cantEscapeSpectating(ServerPlayerEntity instance, Entity entity, Operation<Void> original){
         PlayerComponent component = InitializeComponents.PLAYER.get(instance);
         if(!component.hasBeenCaptured()){
-            instance.setCameraEntity(entity);
+            original.call(instance, entity);
         }
     }
 
@@ -29,11 +30,11 @@ public abstract class ServerPlayerEntityMixin {
         }
     }
 
-    @Redirect(method = "attack", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;setCameraEntity(Lnet/minecraft/entity/Entity;)V"))
-    private void dontChangeTargets(ServerPlayerEntity instance, Entity entity){
+    @WrapOperation(method = "attack", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;setCameraEntity(Lnet/minecraft/entity/Entity;)V"))
+    private void dontChangeTargets(ServerPlayerEntity instance, Entity entity, Operation<Void> original){
         PlayerComponent component = InitializeComponents.PLAYER.get((ServerPlayerEntity) (Object) this);
         if (!component.hasBeenCaptured() && !component.isBeingCaptured()){
-            instance.setCameraEntity(entity);
+            original.call(instance, entity);
         }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,6 +33,9 @@
 		],
 		"voicechat": [
 			"com.sp.sounds.voicechat.BackroomsVoicechatPlugin"
+		],
+		"mixinsquared": [
+			"com.sp.SPBRevampedMixinCanceller"
 		]
 	},
 	"custom": {
@@ -68,13 +71,7 @@
 	},
 	"breaks": {
 		"sodium": "*",
-		"create": "*",
 		"iris": "*",
-		"optifine": "*",
-		"lithium": "*",
-		"phosphor": "*",
-		"starlight": "*",
-		"indium": "*",
-		"modern_industrialization": "*"
+		"optifine": "*"
 	}
 }


### PR DESCRIPTION
- Heavily improves and simplifies mixins by avoiding `@Overwrite` and `@Redirect` calls where possible, which also helps with mod compatibility
- Adds MixinSquared to cancel Veil's AO mixin, allowing the mod to still reapply Veil's "Disable Ambient Occlusion" without reimplementing the entirety of Indigo's AO handling
- Remove a bunch of mods from the breaks list
  - This can be reverted if needed.